### PR TITLE
Add SENTRY_DSN to selenium lambda

### DIFF
--- a/aws/envs/demo/backend/selenium_lambda.tf
+++ b/aws/envs/demo/backend/selenium_lambda.tf
@@ -84,7 +84,8 @@ module "selenium_lambda" {
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name),
     "BUCKET_NAME" = data.terraform_remote_state.stack.outputs.s3_reentry_bucket_id,
-    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"]
+    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"],
+    "SENTRY_DSN" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["appSentryDSN"]
   }
 }
 

--- a/aws/envs/dev/backend/selenium_lambda.tf
+++ b/aws/envs/dev/backend/selenium_lambda.tf
@@ -84,7 +84,8 @@ module "selenium_lambda" {
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name),
     "BUCKET_NAME" = data.terraform_remote_state.stack.outputs.s3_reentry_bucket_id,
-    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"]
+    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"],
+    "SENTRY_DSN" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["appSentryDSN"]
   }
 }
 

--- a/aws/envs/pentest/backend/selenium_lambda.tf
+++ b/aws/envs/pentest/backend/selenium_lambda.tf
@@ -87,7 +87,8 @@ module "selenium_lambda" {
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name),
     "BUCKET_NAME" = data.terraform_remote_state.stack.outputs.s3_reentry_bucket_id,
-    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"]
+    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"],
+    "SENTRY_DSN" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["appSentryDSN"]
   }
 }
 

--- a/aws/envs/prod/backend/selenium_lambda.tf
+++ b/aws/envs/prod/backend/selenium_lambda.tf
@@ -84,7 +84,8 @@ module "selenium_lambda" {
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name),
     "BUCKET_NAME" = data.terraform_remote_state.stack.outputs.s3_reentry_bucket_id,
-    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"]
+    "MAPBOX_ACCESS_TOKEN" = local.secret_data["nextPublicMapboxAccessToken"],
+    "SENTRY_DSN" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["appSentryDSN"]
   }
 }
 


### PR DESCRIPTION
## Summary
- Added `SENTRY_DSN` env var to selenium lambda in all environments (dev, demo, prod, pentest)
- Uses the existing `appSentryDSN` from backend secrets, same pattern as email renderer lambda

## Test plan
- [ ] Terraform plan shows only env var addition, no other changes
- [ ] Deploy to dev and verify Sentry receives events from the lambda