### PR TITLE
MYS-API-PV: Bump selenium-lambda timeout to 900s and memory to 4096MB

### DIFF
--- a/aws/tf-modules/lambda_as_image/lambda.tf
+++ b/aws/tf-modules/lambda_as_image/lambda.tf
@@ -14,8 +14,8 @@ resource "aws_lambda_function" "public_lambda_as_docker_image" {
   role          = var.lambda_role_arn
   package_type  = "Image"
   image_uri     = var.ecr_image
-  timeout       = 300 //seconds
-  memory_size   = 2048 //megs
+  timeout       = 900 //seconds
+  memory_size   = 4096 //megs
 
   environment {
     variables = var.env_vars


### PR DESCRIPTION
## Summary

Pairs with [sst-beta-python-backend#484](https://github.com/UKSpaceAgency/sst-beta-python-backend/pull/484) which restores per-iteration Chrome in the selenium lambda. That fix is more stable but pays Chrome startup cost per (map, key) iteration, so each invocation processes fewer reports per minute. Triple the timeout and double the memory to compensate, and to give Chrome more headroom when rendering very large reentry reports (some reports are 50–75 MB).

- `timeout`: 300 s → 900 s (Lambda max)
- `memory_size`: 2048 MB → 4096 MB

The `lambda_as_image` module is only consumed by the four `selenium_lambda.tf` envs (dev, demo, pentest, prod), so this change is scoped to those lambdas.

## Test plan

- [ ] `terraform plan` in dev shows only `aws_lambda_function.public_lambda_as_docker_image` updated with new timeout/memory
- [ ] After apply, `aws lambda get-function-configuration --function-name selenium-lambda-dev` reports the new values
- [ ] Scheduled run completes more reports per invocation without timing out before world+uk PNGs are written for any given key