### PR TITLE
Wire APP_BACKEND_URL and APP_DOWNLOAD_TOKEN_SECRET on dev backend ECS task

### DIFF
--- a/aws/envs/dev/backend/download_token_secret.tf
+++ b/aws/envs/dev/backend/download_token_secret.tf
@@ -1,0 +1,20 @@
+# HMAC secret used by the BE to sign short-lived download URLs
+# (mint_signed_url / verify_signed_url in app/utils/signed_urls.py).
+#
+# Kept as a separate AWS Secrets Manager secret rather than a key inside the
+# main `${env}-backend` JSON secret so it can be fully Terraform-managed —
+# generated once by `random_id`, rotated by tainting either resource.
+
+resource "random_id" "download_token" {
+  byte_length = 32
+}
+
+resource "aws_secretsmanager_secret" "download_token" {
+  name        = "${var.env_name}-backend-download-token"
+  description = "HMAC secret for signing report download URLs"
+}
+
+resource "aws_secretsmanager_secret_version" "download_token" {
+  secret_id     = aws_secretsmanager_secret.download_token.id
+  secret_string = random_id.download_token.b64_url
+}

--- a/aws/envs/dev/backend/ecsapp.tf
+++ b/aws/envs/dev/backend/ecsapp.tf
@@ -21,6 +21,7 @@ module "backend" {
     { "name" : "APP_NAME", "value" : "API Backend (${var.image_tag})" },
     { "name" : "APP_ENVIRONMENT", "value" : var.env_name },
     { "name" : "APP_FRONTEND_URL", "value" : "https://www.${local.local_r53_domain}" },
+    { "name" : "APP_BACKEND_URL", "value" : "https://${var.app_name}.${local.local_r53_domain}" },
     { "name" : "APP_SENTRY_SAMPLE_RATE", "value" : "0.05" },
     { "name" : "S3_BUCKET_NAME", "value" : data.terraform_remote_state.stack.outputs.s3_bucket_id },
     { "name" : "S3_REENTRY_EVENT_REPORTS_BUCKET_NAME", "value" : data.terraform_remote_state.stack.outputs.s3_reentry_bucket_id },
@@ -97,6 +98,10 @@ module "backend" {
     {
       "name" : "APP_SES_SMTP_PASSWORD",
       "valueFrom" : "${data.aws_secretsmanager_secret.by-name.arn}:sesSmtpPassword::"
+    },
+    {
+      "name" : "APP_DOWNLOAD_TOKEN_SECRET",
+      "valueFrom" : "${data.aws_secretsmanager_secret.by-name.arn}:downloadTokenSecret::"
     }
   ]
   healthcheck_subpath = "/"

--- a/aws/envs/dev/backend/ecsapp.tf
+++ b/aws/envs/dev/backend/ecsapp.tf
@@ -101,7 +101,7 @@ module "backend" {
     },
     {
       "name" : "APP_DOWNLOAD_TOKEN_SECRET",
-      "valueFrom" : "${data.aws_secretsmanager_secret.by-name.arn}:downloadTokenSecret::"
+      "valueFrom" : aws_secretsmanager_secret_version.download_token.arn
     }
   ]
   healthcheck_subpath = "/"


### PR DESCRIPTION
## Summary

Companion to BE PR https://github.com/UKSpaceAgency/sst-beta-python-backend/pull/488. Wires two new env vars on the **dev** backend ECS task:

- `APP_BACKEND_URL` = `https://api.dev.monitor-space-hazards.service.gov.uk` (from `${var.app_name}.${local.local_r53_domain}`) — the public host the BE uses when composing absolute URLs returned in API responses (e.g. `download_url`).
- `APP_DOWNLOAD_TOKEN_SECRET` = HMAC secret for signing short-lived download URLs.

## Token secret is fully Terraform-managed

`aws/envs/dev/backend/download_token_secret.tf`:

```hcl
resource "random_id" "download_token" {
  byte_length = 32
}

resource "aws_secretsmanager_secret" "download_token" {
  name        = "${var.env_name}-backend-download-token"
  description = "HMAC secret for signing report download URLs"
}

resource "aws_secretsmanager_secret_version" "download_token" {
  secret_id     = aws_secretsmanager_secret.download_token.id
  secret_string = random_id.download_token.b64_url
}
```

Why a separate secret rather than adding a key to the existing `${env}-backend` JSON secret: that one is referenced via `data.aws_secretsmanager_secret.by-name` (read-only), so a key add would require migrating the whole secret to TF management. Cleaner to keep this isolated. The ECS execution role's IAM policy (`tf-modules/roles/iam.tf:17-37`) grants `GetSecretValue` on `arn:aws:secretsmanager:*:*:*:*` — the new secret is automatically readable, no IAM changes needed.

## Scope

**Dev only.** Demo / pentest / prod follow once dev validates — same `download_token_secret.tf` copies into each `aws/envs/{env}/backend/` directory (each env gets its own random secret, isolated rotation).

## Test plan

- [ ] `terraform plan` in `aws/envs/dev/backend` shows: 3 new resources (random_id, secret, secret_version), 2 lines added to ecsapp env_vars/secret_env_vars. No churn elsewhere.
- [ ] `terraform apply` via the deploy-to-aws workflow: `gh workflow run deploy-to-aws.yml --repo UKSpaceAgency/sst-beta-infra --ref backend-public-url-and-download-token -f env=dev -f invoker=backend -f image-tag=<sha>`.
- [ ] After apply, ECS task restarts with the new env vars.
- [ ] BE response `download_url` starts with `https://api.dev.monitor-space-hazards.service.gov.uk` and includes `?expires=...&token=...`.
- [ ] Open `download_url` in incognito tab → file downloads pretty-printed. Tamper hex char → 401. Wait past expiry → 401.
- [ ] FE FG26-0013 page renders "Potential Impact" section without 401 errors in network tab.