### PR TITLE
Wire APP_BACKEND_URL and APP_DOWNLOAD_TOKEN_SECRET on demo backend ECS task

### DIFF
--- a/aws/envs/demo/backend/download_token_secret.tf
+++ b/aws/envs/demo/backend/download_token_secret.tf
@@ -1,0 +1,20 @@
+# HMAC secret used by the BE to sign short-lived download URLs
+# (mint_signed_url / verify_signed_url in app/utils/signed_urls.py).
+#
+# Kept as a separate AWS Secrets Manager secret rather than a key inside the
+# main `${env}-backend` JSON secret so it can be fully Terraform-managed —
+# generated once by `random_id`, rotated by tainting either resource.
+
+resource "random_id" "download_token" {
+  byte_length = 32
+}
+
+resource "aws_secretsmanager_secret" "download_token" {
+  name        = "${var.env_name}-backend-download-token"
+  description = "HMAC secret for signing report download URLs"
+}
+
+resource "aws_secretsmanager_secret_version" "download_token" {
+  secret_id     = aws_secretsmanager_secret.download_token.id
+  secret_string = random_id.download_token.b64_url
+}

--- a/aws/envs/demo/backend/ecsapp.tf
+++ b/aws/envs/demo/backend/ecsapp.tf
@@ -20,6 +20,7 @@ module "backend" {
     { "name" : "APP_NAME", "value" : "API Backend (${var.image_tag})" },
     { "name" : "APP_ENVIRONMENT", "value" : var.env_name },
     { "name" : "APP_FRONTEND_URL", "value" : "https://www.${local.local_r53_domain}" },
+    { "name" : "APP_BACKEND_URL", "value" : "https://${var.app_name}.${local.local_r53_domain}" },
     { "name" : "APP_SENTRY_SAMPLE_RATE", "value" : "0.05" },
     { "name" : "APP_FAKE_DATA", "value" : "True" },
     { "name" : "S3_BUCKET_NAME", "value" : data.terraform_remote_state.stack.outputs.s3_bucket_id },
@@ -97,6 +98,10 @@ module "backend" {
     {
       "name" : "APP_SES_SMTP_PASSWORD",
       "valueFrom" : "${data.aws_secretsmanager_secret.by-name.arn}:sesSmtpPassword::"
+    },
+    {
+      "name" : "APP_DOWNLOAD_TOKEN_SECRET",
+      "valueFrom" : aws_secretsmanager_secret_version.download_token.arn
     }
   ]
   healthcheck_subpath = "/"


### PR DESCRIPTION
## Summary

Mirrors PR #89 (dev) for the **demo** environment. Same two env vars the BE needs to:
1. Compose absolute `download_url` values pointing at the public BE host.
2. HMAC-sign / verify those URLs.

## Changes

`aws/envs/demo/backend/ecsapp.tf`:
```hcl
{ "name" : "APP_BACKEND_URL", "value" : "https://${var.app_name}.${local.local_r53_domain}" },
# ...
{ "name" : "APP_DOWNLOAD_TOKEN_SECRET",
  "valueFrom" : aws_secretsmanager_secret_version.download_token.arn }
```

`aws/envs/demo/backend/download_token_secret.tf` (new): Terraform-managed `random_id` + dedicated `aws_secretsmanager_secret` for the HMAC secret. Each env gets its own random secret — isolated rotation.

ECS execution role's wildcard `secretsmanager:GetSecretValue` (`tf-modules/roles/iam.tf:17-37`) covers the new secret without IAM changes.

## Test plan

- [ ] `terraform plan` in `aws/envs/demo/backend` shows: 3 new resources (random_id, secret, secret_version), 2 lines added to ecsapp env_vars/secret_env_vars. No churn elsewhere.
- [ ] `terraform apply` via the deploy-to-aws workflow: `gh workflow run deploy-to-aws.yml --ref backend-public-url-and-download-token-demo -f env=demo -f invoker=backend -f image-tag=<sha>`.
- [ ] After apply, ECS task restarts with the new env vars.
- [ ] After companion BE release (DEMO-1.6.10): `download_url` in API responses starts with `https://api.demo....` and includes `?expires=...&token=...`.
- [ ] FE demo page (e.g. fragmentations/FG26-XXXX) renders "Potential Impact" section without 401s.

## Sequencing note

- This infra PR + a BE release tag (DEMO-1.6.10) need to both be applied for demo to be fully fixed.
- BE deploy alone (without this infra) leaves env vars empty: `download_url` falls back to internal cluster URL (broken) and the HMAC secret is empty (effectively no signature security).
- Apply this infra **before** the DEMO-1.6.10 tag deploy completes for the cleanest rollout.