### PR TITLE
SS-3342: Route prod CDM/TIP ingestion alarms to NSpOC (email + shared Slack)

### DIFF
--- a/aws/envs/demo/backend/notification_sender_lambda.tf
+++ b/aws/envs/demo/backend/notification_sender_lambda.tf
@@ -31,7 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME"  = upper(var.env_name)
-    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
+    "ENVIRONMENT_NAME"   = upper(var.env_name)
+    "SLACK_WEBHOOK_URLS" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrls"]
   }
 }

--- a/aws/envs/demo/backend/notification_sender_lambda.tf
+++ b/aws/envs/demo/backend/notification_sender_lambda.tf
@@ -31,6 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME" = upper(var.env_name)
+    "ENVIRONMENT_NAME"  = upper(var.env_name)
+    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
   }
 }

--- a/aws/envs/dev/backend/notification_sender_lambda.tf
+++ b/aws/envs/dev/backend/notification_sender_lambda.tf
@@ -31,7 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME"  = upper(var.env_name)
-    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
+    "ENVIRONMENT_NAME"   = upper(var.env_name)
+    "SLACK_WEBHOOK_URLS" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrls"]
   }
 }

--- a/aws/envs/dev/backend/notification_sender_lambda.tf
+++ b/aws/envs/dev/backend/notification_sender_lambda.tf
@@ -31,6 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME" = upper(var.env_name)
+    "ENVIRONMENT_NAME"  = upper(var.env_name)
+    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
   }
 }

--- a/aws/envs/pentest/backend/notification_sender_lambda.tf
+++ b/aws/envs/pentest/backend/notification_sender_lambda.tf
@@ -31,7 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME"  = upper(var.env_name)
-    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
+    "ENVIRONMENT_NAME"   = upper(var.env_name)
+    "SLACK_WEBHOOK_URLS" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrls"]
   }
 }

--- a/aws/envs/pentest/backend/notification_sender_lambda.tf
+++ b/aws/envs/pentest/backend/notification_sender_lambda.tf
@@ -31,6 +31,7 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME" = upper(var.env_name)
+    "ENVIRONMENT_NAME"  = upper(var.env_name)
+    "SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
   }
 }

--- a/aws/envs/prod/backend/notification_sender_lambda.tf
+++ b/aws/envs/prod/backend/notification_sender_lambda.tf
@@ -31,6 +31,10 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME" = upper(var.env_name)
+    "ENVIRONMENT_NAME"         = upper(var.env_name)
+    "NOTIFY_API_KEY"           = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["notifyApiKey"]
+    "NOTIFY_TEMPLATE_ID"       = "31ad772f-8483-4eed-bb79-73c8233a8f92"
+    "EMAIL_RECIPIENT"          = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["nspocAlertEmail"]
+    "SHARED_SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["sharedSlackWebhookUrl"]
   }
 }

--- a/aws/envs/prod/backend/notification_sender_lambda.tf
+++ b/aws/envs/prod/backend/notification_sender_lambda.tf
@@ -47,10 +47,12 @@ module "notifications_sender_lambda" {
   s3_key               = "notifications-sender-${var.image_tag}.zip"
 
   env_vars = {
-    "ENVIRONMENT_NAME"         = upper(var.env_name)
-    "SLACK_WEBHOOK_URL"        = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
-    "SES_SENDER_EMAIL"         = var.ses_email_from
-    "EMAIL_RECIPIENT"          = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["nspocAlertEmail"]
-    "SHARED_SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["sharedSlackWebhookUrl"]
+    "ENVIRONMENT_NAME"       = upper(var.env_name)
+    "SES_SENDER_EMAIL"       = var.ses_email_from
+    "SLACK_WEBHOOK_URLS"     = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrls"]
+    "CDM_SLACK_WEBHOOK_URLS" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["cdmSlackWebhookUrls"]
+    "CDM_EMAILS"             = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["cdmEmails"]
+    "TIP_SLACK_WEBHOOK_URLS" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["tipSlackWebhookUrls"]
+    "TIP_EMAILS"             = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["tipEmails"]
   }
 }

--- a/aws/envs/prod/backend/notification_sender_lambda.tf
+++ b/aws/envs/prod/backend/notification_sender_lambda.tf
@@ -19,6 +19,22 @@ resource "aws_iam_role" "lambda-assume-role-notifications-sender" {
   )
 }
 
+resource "aws_iam_role_policy" "notifications_sender_ses_send" {
+  name = "notifications-sender-ses-send"
+  role = aws_iam_role.lambda-assume-role-notifications-sender.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ses:SendEmail", "ses:SendRawEmail"]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
 module "notifications_sender_lambda" {
   source               = "../../../tf-modules/lambda_in_public"
   env_name             = var.env_name
@@ -32,8 +48,7 @@ module "notifications_sender_lambda" {
 
   env_vars = {
     "ENVIRONMENT_NAME"         = upper(var.env_name)
-    "NOTIFY_API_KEY"           = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["notifyApiKey"]
-    "NOTIFY_TEMPLATE_ID"       = "31ad772f-8483-4eed-bb79-73c8233a8f92"
+    "SES_SENDER_EMAIL"         = var.ses_email_from
     "EMAIL_RECIPIENT"          = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["nspocAlertEmail"]
     "SHARED_SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["sharedSlackWebhookUrl"]
   }

--- a/aws/envs/prod/backend/notification_sender_lambda.tf
+++ b/aws/envs/prod/backend/notification_sender_lambda.tf
@@ -48,6 +48,7 @@ module "notifications_sender_lambda" {
 
   env_vars = {
     "ENVIRONMENT_NAME"         = upper(var.env_name)
+    "SLACK_WEBHOOK_URL"        = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["internalSlackWebhookUrl"]
     "SES_SENDER_EMAIL"         = var.ses_email_from
     "EMAIL_RECIPIENT"          = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["nspocAlertEmail"]
     "SHARED_SLACK_WEBHOOK_URL" = jsondecode(data.aws_secretsmanager_secret_version.backend_secret_version.secret_string)["sharedSlackWebhookUrl"]


### PR DESCRIPTION
## Summary
Routes the existing CDM/TIP ingestion-gap alarms to NSpOC, and (re)wires the internal Slack webhook for the notifier Lambda. Pairs with UKSpaceAgency/sst-beta-python-backend#507.

**All envs** (`notification_sender_lambda.tf`): `SLACK_WEBHOOK_URL` now read from Secrets Manager `internalSlackWebhookUrl`. The Lambda's hardcoded webhook fallback was removed in #507, so this must be set or the internal channel stops receiving alerts.

**Prod only**: NSpOC routing for CDM/TIP alarms —
- `SES_SENDER_EMAIL` = `var.ses_email_from` (existing verified SES sender)
- `EMAIL_RECIPIENT` ← `nspocAlertEmail`
- `SHARED_SLACK_WEBHOOK_URL` ← `sharedSlackWebhookUrl`
- IAM inline policy: `ses:SendEmail` / `ses:SendRawEmail`

Email via AWS SES (GOV.UK Notify dropped). Prod CDM/TIP alarm → internal + shared Slack + email; other alarms → internal only; dev/demo/pentest → internal only.

## ⚠️ Secrets Manager prerequisite (before apply)
Add to the `by-name` secret per env:
- **All envs:** `internalSlackWebhookUrl` (the existing internal webhook)
- **Prod only:** `nspocAlertEmail`, `sharedSlackWebhookUrl`

`terraform plan` errors on missing keys until these exist. NSpOC values pending from Mark.

## Test Plan
- [x] `terraform fmt`
- [x] `terraform validate` (prod + dev)
- [ ] `terraform plan` per env after secret keys added