### PR TITLE
SS-3342: Route NSpOC CDM/TIP ingestion alerts to ukspaceagency.support email

### DIFF
--- a/aws/envs/demo/backend/notification_sender_lambda.tf
+++ b/aws/envs/demo/backend/notification_sender_lambda.tf
@@ -32,5 +32,8 @@ module "notifications_sender_lambda" {
 
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name)
+    "SES_SENDER_EMAIL" = var.ses_email_from
+    "CDM_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
+    "TIP_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
   }
 }

--- a/aws/envs/dev/backend/notification_sender_lambda.tf
+++ b/aws/envs/dev/backend/notification_sender_lambda.tf
@@ -32,5 +32,8 @@ module "notifications_sender_lambda" {
 
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name)
+    "SES_SENDER_EMAIL" = var.ses_email_from
+    "CDM_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
+    "TIP_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
   }
 }

--- a/aws/envs/prod/backend/notification_sender_lambda.tf
+++ b/aws/envs/prod/backend/notification_sender_lambda.tf
@@ -32,5 +32,8 @@ module "notifications_sender_lambda" {
 
   env_vars = {
     "ENVIRONMENT_NAME" = upper(var.env_name)
+    "SES_SENDER_EMAIL" = var.ses_email_from
+    "CDM_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
+    "TIP_EMAILS"       = "ukspaceagency.support@thepsc.co.uk"
   }
 }


### PR DESCRIPTION
Wires the per-type alert recipients for the `notifications-sender` lambda (dev/demo/prod).

Adds to each env's `notification_sender_lambda.tf`:
- `SES_SENDER_EMAIL = var.ses_email_from` (reuses the existing verified sender)
- `CDM_EMAILS` / `TIP_EMAILS` = `ukspaceagency.support@thepsc.co.uk`

Together with the CloudWatch alarms already on `main` (`No ingestion of CDMs … 3 hours` / `… TIPs … 25 hours`) and the lambda code in **UKSpaceAgency/sst-beta-python-backend#507**, this delivers SS-3342 (alert NSpOC when CDM/TIP ingestion stalls).

Recipients are env vars (not secrets) — a support mailbox isn't a credential, and keeping it in code makes alert recipients auditable.

SES: prod is out of sandbox (delivers as-is); dev is in sandbox so `ukspaceagency.support@thepsc.co.uk` is being verified there separately for end-to-end testing.